### PR TITLE
Abort configuration if no R2Inference was found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -266,6 +266,8 @@ echo
 
 AG_GST_CHECK_FEATURE(R2INFERENCE, [RidgeRun's Inference Framework], gstinference, [
   AG_GST_PKG_CHECK_MODULES(R2INFERENCE, r2inference-0.0)
+],[],[],[
+  AC_MSG_ERROR([Please install R2Inference from https://github.com/RidgeRun/r2inference.git])
 ])
 
 else


### PR DESCRIPTION
Currently, GstInference is able to build even if R2Inference is not found. The project builds but nothing is actually compiled. This change makes R2Inference a required dependency, failing if R2Inference was not found.