### PR TITLE
Enable the building of the gtk doc by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,7 @@
 # Feature options
 option('enable-tests', type : 'feature', value : 'auto', yield : true, description : 'Build tests')
 option('enable-examples', type : 'feature', value : 'auto', yield : true, description : 'Build examples')
-option('enable-gtk-doc', type : 'boolean', value : false, description : 'Use gtk-doc to build documentation')
+option('enable-gtk-doc', type : 'boolean', value : true, description : 'Use gtk-doc to build documentation')
 option('enable-profiling', type : 'feature', value : 'disabled', yield : true, description: 'Enable profiling building')
 
 # Common options


### PR DESCRIPTION
Enabled by default the documentation generated by gtk-doc with Meson.