### PR TITLE
gstbasebackend: Replace single prediction with multiple prediction

### DIFF
--- a/gst-libs/gst/r2inference/gstbasebackend.cc
+++ b/gst-libs/gst/r2inference/gstbasebackend.cc
@@ -484,6 +484,12 @@ gst_base_backend_process_frame (GstBaseBackend *self, GstVideoFrame *input_frame
   num_outputs = predictions.size();
   GST_LOG_OBJECT (self, "Got %d predictions", num_outputs);
 
+  if (0 == num_outputs) {
+    error.Set (r2i::RuntimeError::Code::WRONG_ENGINE_STATE,
+               "Engine got 0 predictions");
+    goto error;
+  }
+
   /* Concatenate all the outputs in a 1D array */
   for (i = 0; i < num_outputs; i++) {
     /* Compute the size including the new tensor and reallocate memory */

--- a/gst-libs/gst/r2inference/gstbasebackend.cc
+++ b/gst-libs/gst/r2inference/gstbasebackend.cc
@@ -471,7 +471,8 @@ gst_base_backend_process_frame (GstBaseBackend *self, GstVideoFrame *input_frame
   error =
     frame->Configure (input_frame->data[0], input_frame->info.width,
                       input_frame->info.height,
-                      gst_base_backend_cast_format(input_frame->info.finfo->format));
+                      gst_base_backend_cast_format(input_frame->info.finfo->format),
+                      r2i::DataType::Id::FLOAT);
   if (error.IsError ()) {
     goto error;
   }

--- a/gst-libs/gst/r2inference/gstbasebackend.cc
+++ b/gst-libs/gst/r2inference/gstbasebackend.cc
@@ -495,7 +495,7 @@ gst_base_backend_process_frame (GstBaseBackend *self, GstVideoFrame *input_frame
     /* Compute the offset to concatenate the new tensor */
     data_offset = (void *) ((gsize) *prediction_data + *prediction_size);
     /* Could we avoid memory copy ?*/
-    memcpy(data_offset, predictions[i]->GetResultData(), extra_size);
+    memcpy (data_offset, predictions[i]->GetResultData (), extra_size);
     *prediction_size += extra_size;
   }
 


### PR DESCRIPTION
This feature enables the r2inference support for multiple predictions. When received more than 1 output tensor, they will be concatenated into a single 1D array. Currently, no elements should be affected by this since all of them will continue to use the only output available for the supported models.